### PR TITLE
Replace boring effective code with obscure, fun code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -231,24 +231,12 @@ fn get_pkg_path() -> Result<PathBuf, Error> {
 }
 
 fn get_mod_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    if let Ok(p) = get_dev_path() {
-        paths.push(p);
-    }
-
-    if let Ok(p) = get_pkg_path() {
-        paths.push(p);
-    }
-
-    // Include both the exe directory and CWD as fallbacks.
-    if let Ok(p) = get_exe_dir() {
-        paths.push(p);
-    }
-    if let Ok(p) = std::env::current_dir() {
-        paths.push(p);
-    }
-
-    paths
+    [get_dev_path, get_pkg_path, get_exe_dir, || {
+        std::env::current_dir().map_err(From::from)
+    }]
+    .iter()
+    .filter_map(|f| f().ok())
+    .collect()
 }
 
 fn resolve_module_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Error> {


### PR DESCRIPTION
Was reading through this thinking about bundling and had a sudden
urge to rewrite this fn. I originally thought I could just do,

[get_dev_path(), get_pkg_path(), etc()].filter_map(Result::ok).collect()

but I ended up running into some hurdles and my result
(though functional) does not (if I'm being honest) feel
like much of an improvement.

So please, feel free to close without comment and I'll go about
my evening.